### PR TITLE
Update to Ruby 3.2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -41,14 +41,14 @@ RUN zypper --non-interactive install --no-recommends \
   openSUSE-release-ftp \
   rpm-build \
   ruby-devel \
-  "rubygem(ruby:3.1.0:fast_gettext)" \
-  "rubygem(ruby:3.1.0:gettext)" \
-  "rubygem(ruby:3.1.0:raspell)" \
-  "rubygem(ruby:3.1.0:rspec)" \
-  "rubygem(ruby:3.1.0:rubocop)" \
-  "rubygem(ruby:3.1.0:simplecov)" \
-  "rubygem(ruby:3.1.0:yard)" \
-  "rubygem(ruby:3.1.0:yast-rake)" \
+  "rubygem(ruby:3.2.0:fast_gettext)" \
+  "rubygem(ruby:3.2.0:gettext)" \
+  "rubygem(ruby:3.2.0:raspell)" \
+  "rubygem(ruby:3.2.0:rspec)" \
+  "rubygem(ruby:3.2.0:rubocop)" \
+  "rubygem(ruby:3.2.0:simplecov)" \
+  "rubygem(ruby:3.2.0:yard)" \
+  "rubygem(ruby:3.2.0:yast-rake)" \
   screen \
   sgml-skel \
   ShellCheck \
@@ -64,6 +64,13 @@ RUN zypper --non-interactive install --no-recommends \
   && find /usr/lib/locale/* -maxdepth 1 | grep -v -E "(en_US|cs_CZ|es_ES|de_DE|C.utf8)" | xargs rm -rf \
   && find /usr/share/locale -name "*.mo" -delete
 
+# fail when there are multiple Ruby interpreters installed
+# Because it means one part of YaST wanted a different version than the other
+# and requires/imports will fail on the version mismatch.
+RUN if [ `rpm -q --whatprovides "ruby(abi)" | wc -l` -gt 1 ]; then \
+  rpm -q --whatprovides "ruby(abi)"; \
+  echo "Multiple Rubies detected, most likely the system Ruby version has been upgraded."; \
+  echo "Update the versions of the included Ruby gems."; exit 1; fi
 
 COPY yast-ci-cpp /usr/local/bin/
 RUN chmod a+x /usr/local/bin/yast-ci-cpp


### PR DESCRIPTION
## Problem

- This is the same fix as in https://github.com/yast/ci-ruby-container/pull/22
- Build failures in Tumbleweed
- Ruby was upgraded to 3.2

## Solution

- Update the required packages
- Added a Ruby version check

